### PR TITLE
Typo

### DIFF
--- a/courses/da361a/exercises/L00.md
+++ b/courses/da361a/exercises/L00.md
@@ -10,7 +10,7 @@ code: da361a
 
 Syftet med laborationen är att ni ska repetera era Python-kunskaper. Detta ska ni göra genom att bygga en väldigt enkelt variant av spelet `Pokémon`, där användaren väljer en pokemon och kan slåss mot andra tränares pokémon.
 
-## Del 1 - Pokémons
+## Del 1 - Pokémon
 
 Vi ska i denna laboration utgå ifrån en nerbantad version av spelet, och vi nöjer oss med att ha 4st pokémon i vårt spel. De pokemon som ska finnas är:
 

--- a/courses/da361a/exercises/L00.md
+++ b/courses/da361a/exercises/L00.md
@@ -93,7 +93,7 @@ En fight ska följa följande struktur:
         - *Pikachu* attackerar *Squirtle*
 4. Duellen ska fortsätta tills en av pokémonen har 0 i `hp`
 5. Under duelleringens gång ska följande rapporteras till användaren
-    - Aktuell ställning i `hp` för de båda pokémons
+    - Aktuell ställning i `hp` för samtliga Pokémon i matchen
     - Den attackerandes pokémon skada på den försvarande pokémon
     - För att skapa lite spänning ska man vänta 0.5s mellan varje attack
 6. Slutligen ska vinnaren presenteras.


### PR DESCRIPTION
Changed the spelling of "Pokémon" in plural, as it the same as in singular (without an s).